### PR TITLE
Add Hatena entry format detection

### DIFF
--- a/src/hatena_sync/__init__.py
+++ b/src/hatena_sync/__init__.py
@@ -13,6 +13,8 @@ from typing import Any
 import click
 import feedparser
 import requests
+
+from .converters import hatena_to_markdown
 from tqdm import tqdm
 
 HATENA_ATOM_URL = "https://blog.hatena.ne.jp/{user}/{blog}/atom/entry"
@@ -86,6 +88,22 @@ def is_entry_draft(entry: Any) -> bool:
         and entry.app_control.draft == "yes"
     ):
         return True
+    return False
+
+
+def is_markdown_entry(entry: Any) -> bool:
+    """Return True if the entry is in Markdown format.
+
+    Checks both the ``hatena_syntax`` element and the ``type`` attribute of the
+    first ``content`` block because older entries may not include the
+    ``hatena:syntax`` extension.
+    """
+    syntax = getattr(entry, "hatena_syntax", "").lower()
+    if syntax:
+        return syntax == "markdown"
+    if hasattr(entry, "content") and entry.content:
+        ctype = entry.content[0].get("type", "").lower()
+        return "markdown" in ctype
     return False
 
 
@@ -197,6 +215,9 @@ def pull(conf: dict[str, Any]) -> None:
                 ),
                 content,
             )
+
+            if not is_markdown_entry(entry):
+                content = hatena_to_markdown(content)
             if hasattr(entry, "published_parsed"):
                 date_str = datetime(*entry.published_parsed[:6]).strftime("%Y-%m-%d")
             else:

--- a/src/hatena_sync/converters.py
+++ b/src/hatena_sync/converters.py
@@ -1,0 +1,42 @@
+"""Utility converters for Hatena Blog content."""
+from __future__ import annotations
+
+import re
+
+
+def hatena_to_markdown(text: str) -> str:
+    """Convert Hatena notation to Markdown.
+
+    This is a best-effort converter that supports a small subset of Hatena
+    syntax including headings, bold/italic, and simple links.
+    """
+    lines = text.splitlines()
+    converted_lines = []
+    for line in lines:
+        # headings using '*' characters
+        m = re.match(r"^(\*{1,6})\s+(.*)$", line)
+        if m:
+            level = len(m.group(1))
+            converted_lines.append(f"{'#' * level} {m.group(2)}")
+            continue
+        converted_lines.append(line)
+    converted = "\n".join(converted_lines)
+
+    # bold '''text''' -> **text**
+    converted = re.sub(r"'''(.*?)'''", r"**\1**", converted)
+    # italic ''text'' -> *text*
+    converted = re.sub(r"''(.*?)''", r"*\1*", converted)
+    # links [url:title=Title] -> [Title](url)
+    def _link(m: re.Match) -> str:
+        url = m.group("url")
+        title = m.group("title") or url
+        return f"[{title}]({url})"
+
+    pattern_title = re.compile(
+        r"\[(?P<url>https?://[^\s\]:]+):title=(?P<title>[^\]]+)\]"
+    )
+    pattern_simple = re.compile(r"\[(?P<url>https?://[^\s\]]+)\]")
+    converted = pattern_title.sub(_link, converted)
+    converted = pattern_simple.sub(_link, converted)
+
+    return converted

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -1,0 +1,13 @@
+from hatena_sync.converters import hatena_to_markdown
+
+
+def test_hatena_to_markdown_headings():
+    src = "* Heading\n** Sub\n*** SubSub"
+    expected = "# Heading\n## Sub\n### SubSub"
+    assert hatena_to_markdown(src) == expected
+
+
+def test_hatena_to_markdown_formatting_and_links():
+    src = "This is ''italic'' and '''bold''' [https://example.com:title=Example]"
+    expected = "This is *italic* and **bold** [Example](https://example.com)"
+    assert hatena_to_markdown(src) == expected

--- a/tests/test_fetch.py
+++ b/tests/test_fetch.py
@@ -37,6 +37,6 @@ class Resp:
 def test_fetch_remote_entries():
     conf = {"username": "", "blog_id": "b", "api_key": "k"}
     with patch("hatena_sync.requests.get", side_effect=[Resp(PAGE1), Resp(PAGE2)]) as m:
-        entries = fetch_remote_entries(conf)
+        entries = list(fetch_remote_entries(conf))
     assert len(entries) == 2
     assert m.call_count == 2

--- a/tests/test_markdown_detection.py
+++ b/tests/test_markdown_detection.py
@@ -1,0 +1,25 @@
+from types import SimpleNamespace
+from hatena_sync import is_markdown_entry
+
+
+def make_entry(syntax=None, content_type="text/x-hatena-syntax"):
+    content = [{"type": content_type, "value": "body"}]
+    entry = SimpleNamespace(content=content)
+    if syntax is not None:
+        setattr(entry, "hatena_syntax", syntax)
+    return entry
+
+
+def test_is_markdown_entry_via_syntax():
+    entry = make_entry(syntax="markdown")
+    assert is_markdown_entry(entry)
+
+
+def test_is_markdown_entry_via_content_type():
+    entry = make_entry(content_type="text/x-markdown")
+    assert is_markdown_entry(entry)
+
+
+def test_is_markdown_entry_false():
+    entry = make_entry(syntax="hatena")
+    assert not is_markdown_entry(entry)


### PR DESCRIPTION
## Summary
- detect markdown format for each entry via `hatena_syntax` field or content type
- convert entry body using `hatena_to_markdown` when not Markdown
- add unit tests for `is_markdown_entry`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684f324f1c9083309f251783a94e8cc0